### PR TITLE
refactor: replace tokenMap with flattenTokens for balance display cal…

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -9,7 +9,7 @@ import { isMobile } from '@walletconnect/browser-utils';
 import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import bech32 from 'bech32';
 import { CoinGeckoPrices } from 'hooks/useCoingecko';
-import { chainInfos, cosmosTokens, network, oraichainTokens, tokenMap } from 'initCommon';
+import { chainInfos, cosmosTokens, flattenTokens, network, oraichainTokens, tokenMap } from 'initCommon';
 import { getCosmWasmClient } from 'libs/cosmjs';
 import { NetworkChainId } from '@oraichain/common';
 import { store } from 'store/configure';
@@ -75,14 +75,8 @@ export const toSumDisplay = (amounts: AmountDetails): number => {
     // update later
     const balance = amounts[denom];
     if (!balance) continue;
-    // amount += toDisplay(balance, tokenMap[denom]?.decimals);
 
-    const storage = store.getState();
-    const allOraichainTokens = storage.token.allOraichainTokens || [];
-    amount += toDisplay(
-      balance,
-      allOraichainTokens.find((t) => t.contractAddress === denom || t.denom === denom)?.decimals
-    );
+    amount += toDisplay(balance, flattenTokens.find((t) => t.contractAddress === denom || t.denom === denom)?.decimals);
   }
   return amount;
 };


### PR DESCRIPTION
This pull request includes changes to the `src/libs/utils.ts` file to improve token handling and simplify the code. The most important changes include adding a new import for `flattenTokens` and updating the `toSumDisplay` function to use this new import.

Improvements to token handling:

* [`src/libs/utils.ts`](diffhunk://#diff-1bb21cee873a694697a589ff4a6c59e972f1ca83df08be9879900b3c0d722535L12-R12): Added a new import for `flattenTokens` from `initCommon` to ensure all tokens are properly flattened and accessible.

Code simplification:

* [`src/libs/utils.ts`](diffhunk://#diff-1bb21cee873a694697a589ff4a6c59e972f1ca83df08be9879900b3c0d722535L78-R79): Updated the `toSumDisplay` function to use `flattenTokens` for finding the token decimals, removing the need to access the store for `allOraichainTokens`.…culation