### PR TITLE
update token return values in useFillToken hook for consistency

### DIFF
--- a/src/pages/UniversalSwap/Swap/hooks/useFillToken.ts
+++ b/src/pages/UniversalSwap/Swap/hooks/useFillToken.ts
@@ -29,10 +29,10 @@ export const initPairSwap = (): [string, string] => {
   const toDenom = originalToToken?.denom;
 
   if (!fromDenom || !toDenom || fromDenom === toDenom) {
-    return ['usdt', 'orai'];
+    return ['cw20:orai12hzjxfh77wl572gdzct2fxv2arxcwh6gykc7qh:USDT', 'orai'];
   }
 
-  return [fromDenom || 'usdt', toDenom || 'orai'];
+  return [fromDenom || 'cw20:orai12hzjxfh77wl572gdzct2fxv2arxcwh6gykc7qh:USDT', toDenom || 'orai'];
 };
 
 // URL: /universalswap?from=orai&to=usdt
@@ -59,7 +59,6 @@ export const useFillToken = (setSwapTokens: (denoms: [string, string]) => void) 
     const originalToToken = allOraichainTokens.find(
       (token) => token.denom === toDenom || token.contractAddress === toDenom
     );
-    console.log('da den', fromDenom, toDenom, originalFromToken, originalToToken, currentFromDenom, currentToDenom);
 
     if (originalFromToken && originalToToken && (currentFromDenom !== fromDenom || currentToDenom !== toDenom)) {
       currentFromDenom !== fromDenom && params.set(FROM_QUERY_KEY, fromDenom);


### PR DESCRIPTION
This pull request includes changes to the `useFillToken` hook in the `src/pages/UniversalSwap/Swap/hooks/useFillToken.ts` file to improve the handling of token denominations and remove unnecessary logging.

Improvements to token denomination handling:

* [`src/pages/UniversalSwap/Swap/hooks/useFillToken.ts`](diffhunk://#diff-8819d4a3ff3d0caa85d2ede180a65457c9fd159a5a63e640ec3995052f5b8b62L32-R35): Modified the `initPairSwap` function to use a specific contract address format for the USDT token when the denominations are not specified or are the same.
* [`src/pages/UniversalSwap/Swap/hooks/useFillToken.ts`](diffhunk://#diff-8819d4a3ff3d0caa85d2ede180a65457c9fd159a5a63e640ec3995052f5b8b62L32-R35): Updated the return values in the `initPairSwap` function to ensure the correct format for the `fromDenom` and `toDenom` values.

Codebase simplification:

* [`src/pages/UniversalSwap/Swap/hooks/useFillToken.ts`](diffhunk://#diff-8819d4a3ff3d0caa85d2ede180a65457c9fd159a5a63e640ec3995052f5b8b62L62): Removed a console log statement that was used for debugging purposes in the `useFillToken` function.