### PR TITLE
Refactor updateAddedTokens to simplify token filtering logic

### DIFF
--- a/src/reducer/token.ts
+++ b/src/reducer/token.ts
@@ -112,10 +112,7 @@ export const tokenSlice = createSlice({
     updateAddedTokens: (state, action: PayloadAction<any>) => {
       state.addedTokens = [
         ...state.addedTokens,
-        ...action.payload.filter(
-          (token: TokenItemType) =>
-            !state.addedTokens.find((t) => t?.denom === token?.denom || t?.contractAddress === token?.contractAddress)
-        )
+        ...action.payload.filter((token: TokenItemType) => !state.addedTokens.find((t) => t?.denom === token?.denom))
       ];
     }
   }


### PR DESCRIPTION
This pull request includes a change to the `src/reducer/token.ts` file to improve the logic for updating added tokens by simplifying the filter condition.

Improvements to token update logic:

* [`src/reducer/token.ts`](diffhunk://#diff-7c19eb426e1fe53482f604f68d527f43fbe2b8100b04ad8ec1cb443df6666a4dL115-R115): Simplified the filter condition in the `updateAddedTokens` method to only check for duplicate `denom` values, removing the additional check for `contractAddress`.