### PR TITLE
Refactor token verification logic and enhance pool liquidity handling

### DIFF
--- a/src/initCommon.ts
+++ b/src/initCommon.ts
@@ -23,9 +23,7 @@ export const initializeOraidexCommon = async (
   const oraichainTokens = oraidexCommonOg.oraichainTokens;
   const otherChainTokens = oraidexCommonOg.otherChainTokens;
 
-  const allVerifiedOraichainTokens = allOraichainTokens.filter(
-    (token) => !addedTokens.find((addedToken) => addedToken.denom === token.denom)
-  );
+  const allVerifiedOraichainTokens = allOraichainTokens.filter((token) => token.isVerified);
   if (arraysAreDifferent(oraichainTokens, allVerifiedOraichainTokens)) {
     dispatch(updateAllOraichainTokens([...oraichainTokens, ...addedTokens]));
   }

--- a/src/layouts/App.tsx
+++ b/src/layouts/App.tsx
@@ -22,7 +22,6 @@ import Metamask from 'libs/metamask';
 import { buildUnsubscribeMessage, buildWebsocketSendMessage, processWsResponseMsg } from 'libs/utils';
 import { useLoadWalletsTon } from 'pages/Balance/hooks/useLoadWalletsTon';
 import { useEffect, useState } from 'react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useDispatch, useSelector } from 'react-redux';
 import useWebSocket from 'react-use-websocket';
 import { setAddressBookList } from 'reducer/addressBook';
@@ -389,7 +388,6 @@ const App = () => {
       <div className={`app ${theme}`}>
         {/* <button data-featurebase-feedback>Open Widget</button> */}
         <Menu />
-        <ReactQueryDevtools />
         <NoticeBanner openBanner={openBanner} setOpenBanner={setOpenBanner} />
         {/* {(!bannerTime || Date.now() > bannerTime + 86_400_000) && <FutureCompetition />} */}
         <div className="main">

--- a/src/layouts/App.tsx
+++ b/src/layouts/App.tsx
@@ -3,15 +3,18 @@ import {
   WEBSOCKET_RECONNECT_ATTEMPTS,
   WEBSOCKET_RECONNECT_INTERVAL
 } from '@oraichain/oraidex-common';
+import { useWallet } from '@solana/wallet-adapter-react';
 import { useTonConnectUI } from '@tonconnect/ui-react';
 import { isMobile } from '@walletconnect/browser-utils';
-import { TToastType, displayToast } from 'components/Toasts/Toast';
-import { useWallet } from '@solana/wallet-adapter-react';
+import { displayToast, TToastType } from 'components/Toasts/Toast';
 import { ThemeProvider } from 'context/theme-context';
 import { TonNetwork } from 'context/ton-provider';
 import { getListAddressCosmos, getWalletByNetworkFromStorage, interfaceRequestTron, retry } from 'helper';
 import useConfigReducer from 'hooks/useConfigReducer';
+import useLoadTokens from 'hooks/useLoadTokens';
+import { useTronEventListener } from 'hooks/useTronLink';
 import useWalletReducer from 'hooks/useWalletReducer';
+import { initializeOraidexCommon, network } from 'initCommon';
 import SingletonOraiswapV3 from 'libs/contractSingleton';
 import { getCosmWasmClient } from 'libs/cosmjs';
 import Keplr from 'libs/keplr';
@@ -19,18 +22,15 @@ import Metamask from 'libs/metamask';
 import { buildUnsubscribeMessage, buildWebsocketSendMessage, processWsResponseMsg } from 'libs/utils';
 import { useLoadWalletsTon } from 'pages/Balance/hooks/useLoadWalletsTon';
 import { useEffect, useState } from 'react';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useDispatch, useSelector } from 'react-redux';
 import useWebSocket from 'react-use-websocket';
 import { setAddressBookList } from 'reducer/addressBook';
+import routes from 'routes';
 import { persistor, RootState } from 'store/configure';
 import { ADDRESS_BOOK_KEY_BACKUP, PERSIST_VER } from 'store/constants';
 import './index.scss';
-import { initializeOraidexCommon, network } from 'initCommon';
-import useLoadTokens from 'hooks/useLoadTokens';
-import { useTronEventListener } from 'hooks/useTronLink';
 import Menu from './Menu';
-
-import routes from 'routes';
 import { NoticeBanner } from './NoticeBanner';
 import Sidebar from './Sidebar';
 
@@ -389,6 +389,7 @@ const App = () => {
       <div className={`app ${theme}`}>
         {/* <button data-featurebase-feedback>Open Widget</button> */}
         <Menu />
+        <ReactQueryDevtools />
         <NoticeBanner openBanner={openBanner} setOpenBanner={setOpenBanner} />
         {/* {(!bannerTime || Date.now() > bannerTime + 86_400_000) && <FutureCompetition />} */}
         <div className="main">

--- a/src/libs/contractSingleton.ts
+++ b/src/libs/contractSingleton.ts
@@ -764,6 +764,7 @@ export function simulateIncentiveAprPosition(
   const allOraichainTokens = storage.token.allOraichainTokens || [];
   const tokenX = allOraichainTokens.find((token) => extractAddress(token) === poolKey.token_x);
   const tokenY = allOraichainTokens.find((token) => extractAddress(token) === poolKey.token_y);
+  if (!tokenX || !tokenY) return { min: 0, max: 0 };
 
   const positionLiquidityUsdX = ((prices[tokenX?.coinGeckoId] ?? 0) * Number(res.x)) / 10 ** tokenX.decimals;
   const positionLiquidityUsdY = ((prices[tokenY?.coinGeckoId] ?? 0) * Number(res.y)) / 10 ** tokenY.decimals;

--- a/src/pages/Pool-V3/components/PoolList/index.tsx
+++ b/src/pages/Pool-V3/components/PoolList/index.tsx
@@ -45,7 +45,7 @@ export enum PoolColumnHeader {
 const PoolList = ({ search, filterType }: { search: string; filterType: POOL_TYPE }) => {
   const theme = useTheme();
   const { data: price } = useCoinGeckoPrices();
-  const [, setLiquidityPools] = useConfigReducer('liquidityPools');
+  const [poolLiquiditiesFromCache, setLiquidityPools] = useConfigReducer('liquidityPools');
   const [volumnePools, setVolumnePools] = useConfigReducer('volumnePools');
   const [aprInfo, setAprInfo] = useConfigReducer('aprPools');
   const [openTooltip, setOpenTooltip] = useState(false);
@@ -137,7 +137,6 @@ const PoolList = ({ search, filterType }: { search: string; filterType: POOL_TYP
 
   useEffect(() => {
     if (Object.values(poolLiquidities).length > 0) {
-      const totalLiqudity = Object.values(poolLiquidities).reduce((acc, cur) => acc + cur, 0);
       setLiquidityPools(poolLiquidities);
     }
   }, [poolLiquidities, dataPool]);
@@ -153,7 +152,9 @@ const PoolList = ({ search, filterType }: { search: string; filterType: POOL_TYP
       const { type, totalLiquidity: liquidityV2, volume24Hour: volumeV2, liquidityAddr, poolKey } = item || {};
 
       const showLiquidity =
-        type === POOL_TYPE.V3 ? poolLiquidities?.[item?.poolKey] : toDisplay(Math.trunc(liquidityV2 || 0).toString());
+        type === POOL_TYPE.V3
+          ? poolLiquiditiesFromCache?.[item?.poolKey]
+          : toDisplay(Math.trunc(liquidityV2 || 0).toString());
       const showVolume = type === POOL_TYPE.V3 ? volumeV3 : toDisplay(volumeV2 || 0);
 
       let showApr = aprInfo?.[poolKey] || aprInfo?.[liquidityAddr] || {};
@@ -412,16 +413,7 @@ const PoolList = ({ search, filterType }: { search: string; filterType: POOL_TYP
         </div>
       </div>
       <LoadingBox loading={loading} styles={{ minHeight: '60vh', height: 'fit-content' }}>
-        <div className={styles.list}>
-          {filteredPool?.length > 0
-            ? renderList()
-            : !loading && (
-                <div className={styles.nodata}>
-                  {theme === 'light' ? <NoData /> : <NoDataDark />}
-                  <span>{!dataPool.length ? 'No Pools!' : !filteredPool.length && 'No Matched Pools!'}</span>
-                </div>
-              )}
-        </div>
+        <div className={styles.list}>{filteredPool?.length > 0 && renderList()}</div>
 
         <div className={styles.paginate}>
           {totalPages > 1 && (

--- a/src/pages/Pool-V3/hooks/useGetPoolList.ts
+++ b/src/pages/Pool-V3/hooks/useGetPoolList.ts
@@ -2,32 +2,35 @@ import { parseAssetInfo } from '@oraichain/oraidex-common';
 import { PoolWithPoolKey } from '@oraichain/oraidex-contracts-sdk/build/OraiswapV3.types';
 import { useQuery } from '@tanstack/react-query';
 import { CoinGeckoPrices } from 'hooks/useCoingecko';
-import { getTokenInspectorInstance } from 'initTokenInspector';
 import SingletonOraiswapV3 from 'libs/contractSingleton';
 import { getPools } from 'pages/Pools/hooks';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { onChainTokenToTokenItem } from 'reducer/onchainTokens';
 import { addToOraichainTokens } from 'reducer/token';
-import { RootState } from 'store/configure';
+import { RootState, store } from 'store/configure';
 import { PoolInfoResponse } from 'types/pool';
 import { calcPrice } from '../components/PriceRangePlot/utils';
 import { extractAddress, formatPoolData } from '../helpers/format';
+import { inspectTokenFromOraiCommonApi } from 'helper';
 
 export const useGetPoolList = (coingeckoPrices: CoinGeckoPrices<string>) => {
-  const [prices, setPrices] = useState<CoinGeckoPrices<string>>(coingeckoPrices);
-  const [dataPool, setDataPool] = useState([...Array(0)]);
   const dispatch = useDispatch();
   const allOraichainTokens = useSelector((state: RootState) => state.token.allOraichainTokens || []);
-
+  const [prices, setPrices] = useState<CoinGeckoPrices<string>>(coingeckoPrices);
+  const [dataPool, setDataPool] = useState([...Array(0)]);
   const {
     data: poolList,
     refetch: refetchPoolList,
     isLoading: isLoadingGetPoolList
-  } = useQuery<(PoolWithPoolKey | PoolInfoResponse)[]>(['pool-v3-pools', coingeckoPrices], () => getPoolList(), {
-    refetchOnWindowFocus: false
-    // cacheTime: 5 * 60 * 1000,
-  });
+  } = useQuery<(PoolWithPoolKey | PoolInfoResponse)[]>(
+    ['pool-v3-pools', Object.keys(coingeckoPrices).length],
+    getPoolList,
+    {
+      refetchOnWindowFocus: false,
+      cacheTime: 5 * 60 * 1000,
+      enabled: Object.keys(coingeckoPrices).length > 0
+    }
+  );
 
   useEffect(() => {
     if (!poolList || poolList?.length === 0 || Object.keys(coingeckoPrices).length === 0) return;
@@ -43,7 +46,7 @@ export const useGetPoolList = (coingeckoPrices: CoinGeckoPrices<string>) => {
       const tokenY = allOraichainTokens.find((token) => extractAddress(token) === pool.pool_key.token_y);
 
       if (!tokenX || !tokenY) continue;
-      if (tokenX && !prices[tokenX.coinGeckoId]) {
+      if (!prices[tokenX.coinGeckoId]) {
         if (prices[tokenY.coinGeckoId]) {
           // calculate price of X in Y from current sqrt price
           const price = calcPrice(pool.pool.current_tick_index, true, tokenX.decimals, tokenY.decimals);
@@ -51,7 +54,7 @@ export const useGetPoolList = (coingeckoPrices: CoinGeckoPrices<string>) => {
         }
       }
 
-      if (tokenY && !prices[tokenY.coinGeckoId]) {
+      if (!prices[tokenY.coinGeckoId]) {
         if (prices[tokenX.coinGeckoId]) {
           // calculate price of Y in X from current sqrt price
           const price = calcPrice(pool.pool.current_tick_index, false, tokenX.decimals, tokenY.decimals);
@@ -64,7 +67,7 @@ export const useGetPoolList = (coingeckoPrices: CoinGeckoPrices<string>) => {
   }, [poolList]);
 
   useEffect(() => {
-    if (!poolList || poolList.length === 0 || Object.keys(coingeckoPrices).length === 0) return;
+    if (!poolList || poolList.length === 0) return;
 
     (async function formatListPools() {
       const tokenAddresses = new Set<string>();
@@ -85,19 +88,16 @@ export const useGetPoolList = (coingeckoPrices: CoinGeckoPrices<string>) => {
         }
       });
 
+      const HMSTR_DENOM = 'factory/orai17hyr3eg92fv34fdnkend48scu32hn26gqxw3hnwkfy904lk9r09qqzty42/HMSTR';
+      if (tokenAddresses.has(HMSTR_DENOM)) tokenAddresses.delete(HMSTR_DENOM);
       if (tokenAddresses.size > 0) {
-        if (
-          !(
-            tokenAddresses.size === 1 &&
-            // deprecate HMSTR token
-            tokenAddresses.has('factory/orai17hyr3eg92fv34fdnkend48scu32hn26gqxw3hnwkfy904lk9r09qqzty42/HMSTR')
-          )
-        ) {
-          const tokenInspector = await getTokenInspectorInstance();
-          const extendedInfos = await tokenInspector.inspectMultipleTokens([...tokenAddresses]);
-          const convertToTokensType = extendedInfos.map((info) => onChainTokenToTokenItem(info));
-          dispatch(addToOraichainTokens(convertToTokensType));
+        const tokenAddressesArray = [...tokenAddresses];
+        const tokenChunks = [];
+        for (let i = 0; i < tokenAddressesArray.length; i += 30) {
+          const chunk = tokenAddressesArray.slice(i, i + 30);
+          tokenChunks.push(inspectTokenFromOraiCommonApi(chunk));
         }
+        dispatch(addToOraichainTokens(tokenChunks.flat()));
       }
 
       const listPools = (poolList || []).map((p) => formatPoolData(p));


### PR DESCRIPTION
This pull request includes several changes to improve token handling, enhance caching, and refactor code for better readability and performance. The most important changes are grouped by theme below:

### Token Handling Improvements:

* Added a new function `inspectTokenFromOraiCommonApi` to fetch and inspect token data from the OraiCommon API. (`src/helper/index.tsx`)
* Updated `initializeOraidexCommon` to filter verified Oraichain tokens. (`src/initCommon.ts`)
* Refactored `useGetPoolList` to use the new `inspectTokenFromOraiCommonApi` function for token inspection. (`src/pages/Pool-V3/hooks/useGetPoolList.ts`) [[1]](diffhunk://#diff-c0405b8f686c81bc55463091e24d177064093720c5493eb68ab757cd05868f82L5-R33) [[2]](diffhunk://#diff-c0405b8f686c81bc55463091e24d177064093720c5493eb68ab757cd05868f82R91-R100)

### Code Refactoring and Simplification:

* Reorganized imports in `src/layouts/App.tsx` and added `ReactQueryDevtools` for development purposes. (`src/layouts/App.tsx`) [[1]](diffhunk://#diff-3b62dbc9be1b449ae6996a23908d603afb270857d7accfc9c0bbff0593d83a81R6-L33) [[2]](diffhunk://#diff-3b62dbc9be1b449ae6996a23908d603afb270857d7accfc9c0bbff0593d83a81R392)
* Simplified the `simulateIncentiveAprPosition` function to handle missing tokens gracefully. (`src/libs/contractSingleton.ts`)

### Caching and Performance Enhancements:

* Enhanced the `useGetPoolLiquidityVolume` hook by adding caching and refetch configurations. (`src/pages/Pool-V3/hooks/useGetPoolLiquidityVolume.ts`) [[1]](diffhunk://#diff-3b1de2f8cc11f8f58319208834c01d3aa0833bc199cc5165a6df150a9bd44d0eL19-R42) [[2]](diffhunk://#diff-3b1de2f8cc11f8f58319208834c01d3aa0833bc199cc5165a6df150a9bd44d0eL57-R62)
* Updated the `PoolList` component to use cached pool liquidities and volumes. (`src/pages/Pool-V3/components/PoolList/index.tsx`) [[1]](diffhunk://#diff-94ce67de236d5c2ecf15ae534ea16aaebad2b349e628fc3e713dfde9bc7d6e8dL48-R48) [[2]](diffhunk://#diff-94ce67de236d5c2ecf15ae534ea16aaebad2b349e628fc3e713dfde9bc7d6e8dL140) [[3]](diffhunk://#diff-94ce67de236d5c2ecf15ae534ea16aaebad2b349e628fc3e713dfde9bc7d6e8dL156-R157) [[4]](diffhunk://#diff-94ce67de236d5c2ecf15ae534ea16aaebad2b349e628fc3e713dfde9bc7d6e8dL415-R416)